### PR TITLE
Change xml namespace from phpdox.de to phpdox.net

### DIFF
--- a/sample-module/phpdox.xml.dist
+++ b/sample-module/phpdox.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpdox xmlns="http://phpdox.de/config">
+<phpdox xmlns="http://phpdox.net/config">
     <project name="FireGento_SampleModule" source="${basedir}/src" workdir="${basedir}/docs/api/xml">
         <collector backend="parser" />
         <generator output="${basedir}/docs/api">


### PR DESCRIPTION
phpDox has a new XML namespace, see https://github.com/theseer/phpdox/commit/5fabe56b6ced9f0972589caac3e1d15a92b5d55e
